### PR TITLE
Tiny life improvements

### DIFF
--- a/generate-db.sh
+++ b/generate-db.sh
@@ -7,3 +7,5 @@ go get github.com/volatiletech/null/v8
 sqlboiler psql \
     -c sqlboiler.toml \
     --wipe --no-tests
+
+go mod tidy

--- a/sqlboiler.toml
+++ b/sqlboiler.toml
@@ -13,9 +13,6 @@ user   = "postgres"
 pass   = "secret"
 schema = "template"
 sslmode = "disable"
-whitelist = [
-    "example_table"
-]
 
 [[types]]
 [types.match]


### PR DESCRIPTION
The generate-db script always makes mess in go.mod.

It seems unnecessary to have to specify table names to generate database. We can use blacklist if needed.