### PR TITLE
use init connection and fix privilege for initialization

### DIFF
--- a/app.go
+++ b/app.go
@@ -38,7 +38,7 @@ func initialization() {
 	defer conn.Close(ctx)
 
 	// Init the app before the first run.
-	app.Init(db.Pool(), app.AppName(),
+	app.Init(conn, app.AppName(),
 		app.ExecSqlFile("conf/init.sql"),
 		asset.InitAssetTypeFiles("resources/asset-types/*.json"),
 		dashboard.InitWidgetTypeFiles("resources/widget-types/*.json"),

--- a/app.go
+++ b/app.go
@@ -16,6 +16,11 @@
 package main
 
 import (
+	"context"
+	"github.com/eliona-smart-building-assistant/go-eliona/app"
+	"github.com/eliona-smart-building-assistant/go-eliona/asset"
+	"github.com/eliona-smart-building-assistant/go-eliona/dashboard"
+	"github.com/eliona-smart-building-assistant/go-utils/db"
 	"net/http"
 	"template/apiserver"
 	"template/apiservices"
@@ -24,6 +29,21 @@ import (
 	utilshttp "github.com/eliona-smart-building-assistant/go-utils/http"
 	"github.com/eliona-smart-building-assistant/go-utils/log"
 )
+
+func initialization() {
+	ctx := context.Background()
+
+	// Necessary to close used init resources
+	conn := db.NewInitConnectionWithContextAndApplicationName(ctx, app.AppName())
+	defer conn.Close(ctx)
+
+	// Init the app before the first run.
+	app.Init(db.Pool(), app.AppName(),
+		app.ExecSqlFile("conf/init.sql"),
+		asset.InitAssetTypeFiles("resources/asset-types/*.json"),
+		dashboard.InitWidgetTypeFiles("resources/widget-types/*.json"),
+	)
+}
 
 // doAnything is the main app function which is called periodically
 func doAnything() {

--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,8 @@ go 1.20
 
 require (
 	github.com/eliona-smart-building-assistant/app-integration-tests v1.0.1
-	github.com/eliona-smart-building-assistant/go-eliona v1.9.26
-	github.com/eliona-smart-building-assistant/go-utils v1.0.56
+	github.com/eliona-smart-building-assistant/go-eliona v1.9.28
+	github.com/eliona-smart-building-assistant/go-utils v1.0.61
 	github.com/gorilla/mux v1.8.1
 	github.com/volatiletech/sqlboiler/v4 v4.16.2
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -117,12 +117,12 @@ github.com/dnaeon/go-vcr v1.2.0/go.mod h1:R4UdLID7HZT3taECzJs4YgbbH6PIGXB6W/sc5O
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/eliona-smart-building-assistant/app-integration-tests v1.0.1 h1:dlhkHbY4PQlgMBBIow6J9ns7EmCCm8bnHjZ0+e2+sAY=
 github.com/eliona-smart-building-assistant/app-integration-tests v1.0.1/go.mod h1:xEX9Kb1gMQ0rv+ATI0+jamikcEZ/fH6yMHLWauNUCK8=
-github.com/eliona-smart-building-assistant/go-eliona v1.9.26 h1:UA3Poqp/tbTbG+r/8ccG3LesCJLHUfn9qeLGt0YTPUo=
-github.com/eliona-smart-building-assistant/go-eliona v1.9.26/go.mod h1:NNep3Rpce24TwgmBH65p6qAaQA4TpWi4iRAtmUUDYpg=
+github.com/eliona-smart-building-assistant/go-eliona v1.9.28 h1:5SgUmMGDJGTVqvu8Hg8/MWfpLkk6bO9aAIr92rVp5/E=
+github.com/eliona-smart-building-assistant/go-eliona v1.9.28/go.mod h1:YLc8XQa9aW/y938caBypT8+bLJUVsFNV+KhRtKx/Zk8=
 github.com/eliona-smart-building-assistant/go-eliona-api-client/v2 v2.6.1 h1:KgvO7+jACdn3QjPIPNXBzluZdhVze7NX21FEkH3ek7E=
 github.com/eliona-smart-building-assistant/go-eliona-api-client/v2 v2.6.1/go.mod h1:GsmIYeSRwPLX/Kg2yYtxIfhqAvoCjLP/X/k2YALLVSg=
-github.com/eliona-smart-building-assistant/go-utils v1.0.56 h1:yenNP1UZX3bfBH1Q/XMjhb+8itWOyNYx1hIe1nLbWpw=
-github.com/eliona-smart-building-assistant/go-utils v1.0.56/go.mod h1:rcRDJItD62tXkniILeEWE0LpHHitfDJbJzIDsw71AfE=
+github.com/eliona-smart-building-assistant/go-utils v1.0.61 h1:6LjRpXsovtZ5VBSUKs5ZML//x03efuqWMqycjfVhtyg=
+github.com/eliona-smart-building-assistant/go-utils v1.0.61/go.mod h1:rcRDJItD62tXkniILeEWE0LpHHitfDJbJzIDsw71AfE=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=

--- a/main.go
+++ b/main.go
@@ -19,8 +19,6 @@ import (
 	"time"
 
 	"github.com/eliona-smart-building-assistant/go-eliona/app"
-	"github.com/eliona-smart-building-assistant/go-eliona/asset"
-	"github.com/eliona-smart-building-assistant/go-eliona/dashboard"
 	"github.com/eliona-smart-building-assistant/go-utils/common"
 	"github.com/eliona-smart-building-assistant/go-utils/db"
 	"github.com/eliona-smart-building-assistant/go-utils/log"
@@ -46,12 +44,8 @@ func main() {
 	// Necessary to close used init resources, because db.Pool() is used in this app.
 	defer db.ClosePool()
 
-	// Init the app before the first run.
-	app.Init(db.Pool(), app.AppName(),
-		app.ExecSqlFile("conf/init.sql"),
-		asset.InitAssetTypeFiles("resources/asset-types/*.json"),
-		dashboard.InitWidgetTypeFiles("resources/widget-types/*.json"),
-	)
+	// Initialize the app
+	initialization()
 
 	// Starting the service to collect the data for this app.
 	common.WaitForWithOs(


### PR DESCRIPTION
@zdevaty Please visit the change. I implemented the use of `INIT_CONNECTION_STRING` and moved the init code to `app.go` to keep `main.go` as simple as possible.